### PR TITLE
Fix/aged out pipelines

### DIFF
--- a/tap_circle_ci/streams.py
+++ b/tap_circle_ci/streams.py
@@ -94,7 +94,7 @@ def get_all_pipelines(schemas: dict, project: str, state: dict, metadata: dict, 
 
         # We terminate extracting once we come across currently running pipelines
         if not pipeline_is_completed(workflows):
-            continue
+            break
 
         # Transform and write record
         with singer.Transformer() as transformer:

--- a/tap_circle_ci/streams.py
+++ b/tap_circle_ci/streams.py
@@ -139,7 +139,7 @@ def get_all_workflows_for_pipeline(
             f"https://circleci.com/api/v2/pipeline/{pipeline.get('id')}/workflow"
         ))
     except NotFoundException:
-        LOGGER.warn(f'Pipeline not found (probably aged out): {pipeline}')
+        LOGGER.warning(f'Pipeline not found (probably aged out): {pipeline}')
         return []
 
 


### PR DESCRIPTION
# Motivation

Seeing now that the errors for pipelines missing are for pipelines which are more than 6 months ago. Going to assume these just aged out of CCI and we can ignore this and pull over partial data. Part of the rub here, is that Circle doesn't appear to have any indication as to what's happened here, and we're just in a lurch, so it's unclear whether we can know how far back in time we can go before getting partial data, but we apparently can still fetch some of this data from the API.