### PR TITLE
Amann/fix/fetch executor information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 __pycache__/
 
 venv/
-sample_config.json
 catalog.json
+config.json
+state.json

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This tap:
 1. Install
 
    ```bash
-   git clone git@github.com:sisudata/tap-circle-ci.git && cd tap-circle-ci && pip install -e .
+   git clone git@github.com:apollographql/tap-circleci.git && cd tap-circleci && pip install -e .
    ```
 
 2. Create a Circle CI access token
@@ -66,7 +66,7 @@ This tap:
 4. Run the tap in discovery mode to get catalog.json file
 
    ```bash
-   tap-circle-ci --config config.json --discover > catalog.json
+   tap-circleci --config config.json --discover > catalog.json
    ```
 
 5. In the catalog.json file, select the streams to sync
@@ -110,16 +110,16 @@ This tap:
 
 6. Run the application (will print records and other messages to the console)
 
-   `tap-circle-ci` can be run with:
+   `tap-circleci` can be run with:
 
    ```bash
-   tap-circle-ci --config config.json --catalog catalog.json
+   tap-circleci --config config.json --catalog catalog.json
    ```
 
    To save output to a file:
 
    ```bash
-   tap-circle-ci --config config.json --catalog catalog.json > output.txt
+   tap-circleci --config config.json --catalog catalog.json > output.txt
    ```
 
    It is our intention that this singer tap gets used with a singer target, which will load the output into a database.
@@ -134,8 +134,8 @@ This tap:
      "type": "STATE",
      "value": {
        "bookmarks": {
-         "gh/sisudata/tap-circle-ci": {
-           "pipelines": { "since": "2021-05-28T22:02:27.620127Z" }
+         "gh/apollographql/tap-circleci": {
+           "pipelines": { "since": "2023-11-15T00:00:00.000000Z" }
          }
        }
      }
@@ -145,7 +145,7 @@ This tap:
    Select the `value` key, store it to a JSON file, and run:
 
    ```bash
-   tap-circle-ci --config config.json --catalog catalog.json --state state.json
+   tap-circleci --config config.json --catalog catalog.json --state state.json
    ```
 
 ## Configuration

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 python -m venv venv/tap-circle-ci
-source /code/venv/target-postgres/bin/activate
+source /code/venv/tap-circle-ci/bin/activate
 
 pip install -e .[tests]
 

--- a/sample-config.json
+++ b/sample-config.json
@@ -1,0 +1,4 @@
+{
+    "token": "TODO",
+    "project_slugs": "gh/singer-io/singer-python gh/singer-io/getting-started gh/apollographql/tap-circleci"
+}

--- a/sample-state.json
+++ b/sample-state.json
@@ -1,0 +1,7 @@
+{
+  "bookmarks": {
+    "gh/apollographql/tap-circle-ci": {
+      "pipelines": { "since": "2023-11-15T00:00:00.000000Z" }
+    }
+  }
+}

--- a/tap_circle_ci/client.py
+++ b/tap_circle_ci/client.py
@@ -38,9 +38,9 @@ class NotFoundException(Exception):
     pass
 
 
-def get(source: str, url: str, headers: dict = {}):
+def get_single_entry(source: str, url: str, headers: dict = {}):
     """
-    Get a single page from the provided url
+    Get a single entryp from the provided url
     """
 
     with metrics.http_request_timer(source) as timer:
@@ -70,7 +70,7 @@ def get_all_pages(source: str, url: str, headers: dict = {}):
         LOGGER.info(f'get_all_pages: Paginating({counter}): {source}')
         counter += 1
 
-        r = get(source, temp_url, headers)
+        r = get_single_entry(source, temp_url, headers)
         r.raise_for_status()
         data = r.json()
         yield data

--- a/tap_circle_ci/schemas/jobs.json
+++ b/tap_circle_ci/schemas/jobs.json
@@ -17,6 +17,18 @@
     "workflow_id": {
       "type": "string"
     },
+    "contexts": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
     "dependencies": {
       "type": [
         "null",

--- a/tap_circle_ci/streams.py
+++ b/tap_circle_ci/streams.py
@@ -217,7 +217,6 @@ def get_all_jobs_for_workflow(
 
     workflow_id = workflow.get("id")
     slug = workflow.get("project_slug")
-    build_num = job.get("job_number")
 
     if job_counter is None:
         job_counter = metrics.record_counter('jobs')
@@ -225,9 +224,12 @@ def get_all_jobs_for_workflow(
     jobs_url = f"https://circleci.com/api/v2/workflow/{workflow_id}/job"
     extraction_time = singer.utils.now()
     for job in get_all_items('jobs', jobs_url):
-        job_url = f"https://circleci.com/api/v2/project/{slug}/job/{build_num}"
+        build_num = job.get("job_number")
+        job_details = {}
 
-        job_details = get_single_entry('job', job_url)
+        if build_num:
+            job_url = f"https://circleci.com/api/v2/project/{slug}/job/{build_num}"
+            job_details = get_single_entry('job', job_url).json()
 
         # add in workflow_id and pipeline_id
         job.update({


### PR DESCRIPTION
# Motivation

Presently, the data that this tap for jobs focuses solely those data objects returned by fetching all of a workflow's jobs: https://circleci.com/docs/api/v2/index.html#operation/listWorkflowJobs

Those objects, are distinctly different from the full Job Details: https://circleci.com/docs/api/v2/index.html#operation/getJobDetails

This tap is still leveraging the V1 Build implementation to be able to fetch step information: https://circleci.com/docs/api/v1/index.html#jobs

Unfortunately, neither the slimmed down Workflows Jobs data, nor the V1 Build information, has details about things like parallelism, contexts, nor executor (which is the real data I personally am after). So, instead, we submit _yet_ another request to fetch the V2 job details.