### PR TITLE
Fix: Steps stream has job_id = workflow_id...which is hella wrong

### DIFF
--- a/tap_circle_ci/streams.py
+++ b/tap_circle_ci/streams.py
@@ -270,6 +270,7 @@ def get_all_steps_for_job(
         step_counter = metrics.record_counter('jobs')
 
     workflow_id = workflow.get("id")
+    job_id = job.get("id")
     slug = workflow.get("project_slug")
     build_num = job.get("job_number")
 
@@ -288,10 +289,10 @@ def get_all_steps_for_job(
             step.update({
                 '_pipeline_id': pipeline_id,
                 '_workflow_id': workflow_id,
-                '_job_id': workflow_id,
+                '_job_id': job_id,
                 'pipeline_id': pipeline_id,
                 'workflow_id': workflow_id,
-                'job_id': workflow_id,
+                'job_id': job_id,
                 '_index': idx
             })
 


### PR DESCRIPTION
# Motivation

Glaring bug that simply hasn't been caught till today. Never linked the job up to the steps correctly.